### PR TITLE
Release: v1.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,12 @@ jobs:
           name: Install deps
           command: yarn install --frozen-lockfile
 
+      - save_cache:
+          name: Save Cache
+          key: modules-rev1-{{ checksum "yarn.lock" }}
+          paths:
+            - ./node_modules
+
       - run:
           name: Lint
           command: yarn lint
@@ -30,12 +36,6 @@ jobs:
       - run:
           name: Upload coverage report
           command: yarn codecov
-
-      - save_cache:
-          name: Save Cache
-          key: modules-rev1-{{ checksum "yarn.lock" }}
-          paths:
-            - ./node_modules
 
       - persist_to_workspace:
           root: .

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ function buildValue(name, schema, value, refs) {
     if (schema.type === 'array')
       return (value === undefined) ? [] : buildArray(name, schema, value, refs);
 
-    if (value === undefined || schema === undefined)
+    if (value === undefined)
       return undefined;
 
     if (schema.type === 'object')

--- a/index.js
+++ b/index.js
@@ -24,8 +24,8 @@ class FormatManager {
   }
 
   // Register new string format with the given name
-  register(name, { toString, fromString }) {
-    this.formats[name] = { toString, fromString };
+  register(name, { dump, load }) {
+    this.formats[name] = { dump, load };
   }
 
   // Find string format by name.
@@ -99,7 +99,7 @@ class TypedModel {
           processed = value.asObject();
         else if (propSchema.type === 'string' && typeof value !== 'string') {
           const format = TypedModel.formats.find(propSchema.format);
-          processed = format ? format.toString(value) : value && value.toString();
+          processed = format ? format.dump(value) : (value && value.toString());
         }
         else
           processed = value;
@@ -181,7 +181,7 @@ function buildValue(name, schema, value, refs) {
 
     if (schema.type === 'string' && schema.format) {
       const format = TypedModel.formats.find(schema.format);
-      return format ? format.fromString(value) : value;
+      return format ? format.load(value) : value;
     }
 
     return value;
@@ -210,8 +210,8 @@ function buildArray(name, schema, data, refs) {
 
 // handle date and date-time formats out of the box (can be overwritten).
 TypedModel.formats.register('date', {
-  fromString: str => str && new Date(str),
-  toString: value => {
+  load: str => str && new Date(str),
+  dump: value => {
     if (!value)
       return value;
 
@@ -220,8 +220,8 @@ TypedModel.formats.register('date', {
   },
 });
 TypedModel.formats.register('date-time', {
-  fromString: str => str && new Date(str),
-  toString: value => value && value.toISOString(),
+  load: str => str && new Date(str),
+  dump: value => value && value.toISOString(),
 });
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-models",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -344,8 +344,8 @@ describe('TypedModel', () => {
       }
 
       TypedModel.formats.register('custom', {
-        fromString: str => new CustomModel(str),
-        toString: value => value.toString(),
+        load: str => new CustomModel(str),
+        dump: value => value.toString(),
       });
 
       class TestModel extends TypedModel {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -43,7 +43,7 @@ class Table extends TypedModel {
 }
 
 
-describe('BusinessModel', () => {
+describe('TypedModel', () => {
   describe('constructor()', () => {
     it('Works with plain objects.', () => {
       const user = new User({
@@ -419,6 +419,30 @@ describe('BusinessModel', () => {
       } catch(err) {
         expect(err.traceback).to.equal('$.items[2].dynamic');
       }
+    });
+
+
+    it('Does not convert undefined to dates and vice-versa', () => {
+      class TestModel extends TypedModel {
+        static props = {
+          'createdAt': { type: 'string', format: 'date' },
+          'updatedAt': { type: 'string', format: 'date' },
+        };
+      }
+
+      const instance = new TestModel({
+        createdAt: undefined,
+        updatedAt: null,
+      });
+
+      expect(instance.createdAt).to.be.undefined;
+      expect(instance.updatedAt).to.be.null;
+
+      const data = instance.asObject();
+      expect(data).to.eql({
+        createdAt: undefined,
+        updatedAt: null,
+      })
     });
   });
 


### PR DESCRIPTION
v1.2.1
======


Changes
-------

- From now on, the format converters will use new names: load/dump which will
  replace the current fromString/toString respectively.
