### PR TITLE
Release: v1.3.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,17 +211,11 @@ function buildArray(name, schema, data, refs) {
 // handle date and date-time formats out of the box (can be overwritten).
 TypedModel.formats.register('date', {
   load: str => str && new Date(str),
-  dump: value => {
-    if (!value)
-      return value;
-
-    const datestr = value.toISOString();
-    return datestr.substr(0, datestr.indexOf('T'));
-  },
+  dump: val => val && val.toISOString().substr(0, 10),
 });
 TypedModel.formats.register('date-time', {
   load: str => str && new Date(str),
-  dump: value => value && value.toISOString(),
+  dump: val => val && val.toISOString(),
 });
 
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     }
   },
   "dependencies": {
+    "date-fns": "^2.16.1",
     "jsonschema": "^1.2.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-models",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -444,6 +444,19 @@ describe('TypedModel', () => {
         updatedAt: null,
       })
     });
+
+    it('Format converters properly handle null value', () => {
+      class TestModel extends TypedModel {
+        static props = {
+          'imageUrl': {type: 'string'},
+        };
+      }
+
+      const instance = new TestModel({ imageUrl: null });
+
+      expect(instance.imageUrl).to.be.null;
+      expect(instance.asObject().imageUrl).to.be.null;
+    });
   });
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,6 +1140,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-fns@^2.16.1:
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
+  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"


### PR DESCRIPTION
v1.3.1
======


Features
--------

- Add modelAsObject() for easy use with Array.map. The original .asObject()
  method is now implemented using the new modelAsObject().


Changes
-------

- Use date-fns in date converters.
