### PR TITLE
Release: v1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ will import from `dist/`.
 
 TODO: Need to setup babel with jest so we can import from `src/`.
 
+
 ## Example
 
 *You can find this example in [./examples/example.js](examples/example.js).

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ tree like structures. Arrays are of course also supported.
     npm i typed-models
     yarn add typed-models
 
+### Development
+
+Before running the tests you must build the lib using `yarn build`. The tests
+will import from `dist/`.
+
+TODO: Need to setup babel with jest so we can import from `src/`.
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typed-models",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "main": "./dist/index.js",
   "browser": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -81,14 +81,10 @@
       ]
     }
   },
-  "dependencies": {
-    "date-fns": "^2.16.1",
-    "jsonschema": "^1.2.6"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.11.6",
     "@babel/core": "^7.11.6",
-    "@babel/plugin-proposal-class-properties": "^7.10.4",
     "@babel/preset-env": "^7.11.5",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "chai": "^4.2.0",

--- a/src/util.js
+++ b/src/util.js
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export const json = (data, indent) => JSON.stringify(data, null, indent);
 
 
-const json = (data, indent) => JSON.stringify(data, null, indent);
-
-
-function mapObject(obj, mapperFn) {
+export function mapObject(obj, mapperFn) {
   return Object.fromEntries(
     Object.entries(obj)
       .map((entry, index) => mapperFn(...entry, index))
@@ -29,7 +27,7 @@ function mapObject(obj, mapperFn) {
 
 
 // A little helper to manage JSONSchema string formats.
-class FormatManager {
+export class FormatManager {
   constructor() {
     this.formats = {};
   }
@@ -55,7 +53,7 @@ class FormatManager {
 
 
 // Check if the given object is empty
-function isEmpty(obj) {
+export function isEmpty(obj) {
   if (!obj)
     return true;
 
@@ -63,9 +61,22 @@ function isEmpty(obj) {
 }
 
 
-module.exports = {
+export function formatDate(date) {
+  const year = date.getFullYear();
+  let month = date.getMonth() + 1;
+  let day = date.getDate();
+
+  month = (month < 10) ? (`0${month}`) : month;
+  day = (day < 10) ? (`0${day}`) : day;
+
+  return `${year}-${month}-${day}`;
+}
+
+
+export default {
   json,
   mapObject,
   isEmpty,
   FormatManager,
+  formatDate,
 };

--- a/tests/TypedModel.spec.js
+++ b/tests/TypedModel.spec.js
@@ -756,27 +756,6 @@ describe('TypedModel', () => {
   });
 
 
-  describe('validate()', () => {
-    it('Returns nothing if validation was successful', () => {
-      const err = User.validate({
-        name: 'John',
-        surname: 'Doe',
-      });
-
-      expect(err).to.be.undefined;
-    });
-
-
-    it('Returns error if validation failed', () => {
-      const err = User.validate({
-        firstName: 'John',
-        lastName: 'Doe',
-      });
-
-      expect(err).to.not.be.undefined;
-    });
-  });
-
   describe('setValues()', () => {
     it('Does not set property if not given in values', () => {
       const user = new User({ name: 'John', surname: 'Jones' });

--- a/tests/util.spec.js
+++ b/tests/util.spec.js
@@ -92,3 +92,19 @@ describe('isEmpty()', () => {
 });
 
 
+describe('formatDate()', () => {
+  it('Correctly converts the date to string', () => {
+    const examples = [
+      '2020-10-12',
+      '2020-05-07',
+      '1990-01-01',
+      '2200-12-31',
+    ]
+
+    examples.forEach(inDateStr => {
+      expect(util.formatDate(new Date(inDateStr))).to.equal(inDateStr);
+    });
+  });
+});
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,11 +1512,6 @@ babel-plugin-syntax-class-properties@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
   integrity sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
-  integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
-
 babel-plugin-transform-class-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
@@ -1526,14 +1521,6 @@ babel-plugin-transform-class-properties@^6.24.1:
     babel-plugin-syntax-class-properties "^6.8.0"
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
-
-babel-plugin-transform-object-rest-spread@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
-  integrity sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=
-  dependencies:
-    babel-plugin-syntax-object-rest-spread "^6.8.0"
-    babel-runtime "^6.26.0"
 
 babel-preset-current-node-syntax@^0.1.3:
   version "0.1.3"
@@ -2015,11 +2002,6 @@ data-urls@^2.0.0:
     abab "^2.0.3"
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
-
-date-fns@^2.16.1:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
-  integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
@@ -3623,11 +3605,6 @@ json5@^2.1.2:
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
-
-jsonschema@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.6.tgz#52b0a8e9dc06bbae7295249d03e4b9faee8a0c0b"
-  integrity sha512-SqhURKZG07JyKKeo/ir24QnS4/BV7a6gQy93bUSe4lUdNp0QNpIz2c9elWJQ9dpc5cQYY6cvCzgRwy0MQCLyqA==
 
 jsprim@^1.2.2:
   version "1.4.1"


### PR DESCRIPTION
v1.5.0
======


Changes
-------

- Remove TypedModel.validate(). It was the only place jsonschema was used and
  we do not need it as an unnecessary dependency.
- Reimplement date formatter to not use date-fns. Same as the above, this is a
  very simple case and no need to pull an external library just for it.
